### PR TITLE
stop triggering renovate prs for submodule updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,8 +20,5 @@
   "separateMinorPatch": true,
   "patch": {
     "groupName": "all patch updates"
-  },
-  "git-submodules": {
-    "enabled": true
   }
 }


### PR DESCRIPTION
This is not as useful as I would hope and is only triggering needless ci runs

Signed-off-by: Robert Kruszewski <github@robertk.io>
