### PR TITLE
ci: enable linux_amd64_musl extension build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,23 +1,27 @@
-# Host build-script linkage for the linux_amd64_musl extension build.
+# Build flags for the linux_amd64_musl extension build. These MUST live in cargo
+# config (not corrosion's RUSTFLAGS env), for two reasons:
 #
-# In the Alpine/musl CI image the *host* is x86_64-unknown-linux-musl, so build
-# scripts are compiled for that triple. Rust defaults `crt-static = on` for musl,
-# producing a statically linked build-script executable. The `custom-labels`
-# crate (a mandatory dependency of vortex-duckdb / vortex-io) runs `bindgen` in
-# its build script, and bindgen `dlopen()`s libclang at runtime — which is
-# impossible from a fully static binary:
+#  1. Host build scripts. In the Alpine/musl image the host is
+#     x86_64-unknown-linux-musl, so build scripts compile for that triple. Rust
+#     defaults `crt-static = on` for musl, producing a *static* build-script
+#     binary. The `custom-labels` crate (a mandatory dep of vortex-duckdb /
+#     vortex-io) runs bindgen in its build script, and bindgen dlopen()s
+#     libclang — impossible from a static binary:
+#         Unable to find libclang: "... libclang.so ... could not be opened:
+#         Dynamic loading not supported"
+#     Under `--target`, env RUSTFLAGS only affects the target artifacts, not host
+#     build scripts. A `[target.<triple>]` config table, by contrast, also
+#     applies to host build scripts of that triple (target-applies-to-host,
+#     default true) — so disabling crt-static here makes them dynamically linked
+#     and able to dlopen libclang.
 #
-#   Unable to find libclang: "... libclang.so ... could not be opened:
-#   Dynamic loading not supported"
+#  2. Relocation. The vortex crate is built as a staticlib folded into the
+#     loadable extension shared object; musl's default non-PIC codegen fails with
+#     "relocation R_X86_64_32 ... cannot be used when making a shared object".
+#     -Crelocation-model=pic fixes that for the target crate.
 #
-# Disabling crt-static for the musl triple makes host build scripts dynamically
-# linked, so they can dlopen libclang and the musl build proceeds.
-#
-# Note: corrosion already passes the equivalent flag (plus -Crelocation-model=pic)
-# to the extension *target* via RUSTFLAGS (see CMakeLists.txt). Under `--target`,
-# env RUSTFLAGS only affects the final target artifacts, not host build scripts;
-# this `[target.<triple>]` table — applied to host build scripts via
-# target-applies-to-host (default true) — is what covers them. Only consulted
-# when building for the musl triple, so glibc/macOS/Windows builds are unaffected.
+# Setting RUSTFLAGS env (as corrosion does) would make cargo IGNORE this table,
+# so the flags are kept here instead. Only consulted when building for the musl
+# triple, so glibc/macOS/Windows builds are unaffected.
 [target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=-crt-static"]
+rustflags = ["-C", "target-feature=-crt-static", "-C", "relocation-model=pic"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,23 @@
+# Host build-script linkage for the linux_amd64_musl extension build.
+#
+# In the Alpine/musl CI image the *host* is x86_64-unknown-linux-musl, so build
+# scripts are compiled for that triple. Rust defaults `crt-static = on` for musl,
+# producing a statically linked build-script executable. The `custom-labels`
+# crate (a mandatory dependency of vortex-duckdb / vortex-io) runs `bindgen` in
+# its build script, and bindgen `dlopen()`s libclang at runtime — which is
+# impossible from a fully static binary:
+#
+#   Unable to find libclang: "... libclang.so ... could not be opened:
+#   Dynamic loading not supported"
+#
+# Disabling crt-static for the musl triple makes host build scripts dynamically
+# linked, so they can dlopen libclang and the musl build proceeds.
+#
+# Note: corrosion already passes the equivalent flag (plus -Crelocation-model=pic)
+# to the extension *target* via RUSTFLAGS (see CMakeLists.txt). Under `--target`,
+# env RUSTFLAGS only affects the final target artifacts, not host build scripts;
+# this `[target.<triple>]` table — applied to host build scripts via
+# target-applies-to-host (default true) — is what covers them. Only consulted
+# when building for the musl triple, so glibc/macOS/Windows builds are unaffected.
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,5 +19,5 @@ jobs:
       ci_tools_version: v1.5.3
       duckdb_version: v1.5.3
       extension_name: vortex
-      exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;windows_amd64;linux_amd64_musl"
+      exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;windows_amd64"
       extra_toolchains: "rust"

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -20,4 +20,7 @@ jobs:
       duckdb_version: v1.5.3
       extension_name: vortex
       exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;windows_amd64"
+      # linux_amd64_musl is opt_in in extension-ci-tools' distribution_matrix.json,
+      # so removing it from exclude_archs is not enough — it must also be opted in here.
+      opt_in_archs: "linux_amd64_musl"
       extra_toolchains: "rust"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,20 +80,12 @@ corrosion_set_env_vars(
     "DUCKDB_VERSION=${DUCKDB_VERSION}"
 )
 
-# On musl (Alpine) the vortex crate is built as a staticlib and folded into the
-# loadable extension, which is a shared object. Rust's x86_64-unknown-linux-musl
-# target defaults to a static CRT and non-PIC codegen, so the archive fails to
-# link into a shared object (relocation R_X86_64_32 ... can not be used when
-# making a shared object). Build it position-independent against a dynamic CRT.
-# Scoped to musl via the loader path so glibc/macOS builds are unaffected.
-if(EXISTS "/lib/ld-musl-x86_64.so.1")
-    message(STATUS "musl libc detected: building vortex crate as PIC with dynamic CRT")
-    corrosion_add_target_rustflags(
-        ${VORTEX_RUST_TARGET_NAME}
-        "-Ctarget-feature=-crt-static"
-        "-Crelocation-model=pic"
-    )
-endif()
+# NOTE: musl (Alpine) build flags live in .cargo/config.toml under
+# [target.x86_64-unknown-linux-musl], NOT here. They must be applied via cargo
+# config rather than corrosion's RUSTFLAGS env, because (a) under --target, env
+# RUSTFLAGS only reaches the target artifacts, not the *host* build scripts, and
+# the custom-labels build script needs a dynamic CRT to dlopen libclang; and
+# (b) setting RUSTFLAGS env makes cargo ignore the [target] config entirely.
 
 include_directories(src/include vortex/vortex-duckdb/include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,21 @@ corrosion_set_env_vars(
     "DUCKDB_VERSION=${DUCKDB_VERSION}"
 )
 
+# On musl (Alpine) the vortex crate is built as a staticlib and folded into the
+# loadable extension, which is a shared object. Rust's x86_64-unknown-linux-musl
+# target defaults to a static CRT and non-PIC codegen, so the archive fails to
+# link into a shared object (relocation R_X86_64_32 ... can not be used when
+# making a shared object). Build it position-independent against a dynamic CRT.
+# Scoped to musl via the loader path so glibc/macOS builds are unaffected.
+if(EXISTS "/lib/ld-musl-x86_64.so.1")
+    message(STATUS "musl libc detected: building vortex crate as PIC with dynamic CRT")
+    corrosion_add_target_rustflags(
+        ${VORTEX_RUST_TARGET_NAME}
+        "-Ctarget-feature=-crt-static"
+        "-Crelocation-model=pic"
+    )
+endif()
+
 include_directories(src/include vortex/vortex-duckdb/include)
 
 set(EXTENSION_NAME ${TARGET_NAME}_extension)


### PR DESCRIPTION
## What

Enables the `linux_amd64_musl` build in CI so the `vortex` extension is built and tested against musl libc (Alpine/static).

## Changes

- **`.github/workflows/MainDistributionPipeline.yml`**: Remove `linux_amd64_musl` from `exclude_archs`. This turns on the musl target in the reusable `_extension_distribution.yml` pipeline, which builds the extension inside an Alpine/musl container. The `vortex-duckdb` Rust crate is compiled (via corrosion) for `x86_64-unknown-linux-musl`.

## Verification

CI on this PR now includes a `linux_amd64_musl` job. Since the musl/Alpine build can't be reproduced on the glibc Linux CI sandbox locally, the green CI run on this PR is the verification. I'll watch the PR and fix any musl-specific build failures that surface.

https://claude.ai/code/session_01HJ7A8P4YMVgJ64bZyqpJHV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJ7A8P4YMVgJ64bZyqpJHV)_