### PR TITLE
include table_function.h in vortex_extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ corrosion_set_env_vars(
     "DUCKDB_VERSION=${DUCKDB_VERSION}"
 )
 
-include_directories(src/include vortex/vortex-duckdb/include)
+include_directories(src/include vortex/vortex-duckdb/include vortex/vortex-duckdb/cpp/include)
 
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)

--- a/src/vortex_extension.cpp
+++ b/src/vortex_extension.cpp
@@ -1,6 +1,7 @@
 #define DUCKDB_EXTENSION_MAIN
 
 #include "vortex_extension.hpp"
+#include "duckdb_vx/table_function.h"
 #include "vortex.h"
 
 using namespace duckdb;


### PR DESCRIPTION
vortex.h depends on duckdb_vx_string_map structure which
is supplied by table_function.h. Since it's a C++-side function,
we can't include it in vortex.h directly.

Add include of table_function.h to solve this
