### PR TITLE
Enable LTO for .duckdb_extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,11 +66,16 @@ if(EXISTS "/.dockerenv")
     endif()
 endif()
 
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(VORTEX_CARGO_PROFILE PROFILE release-lto)
+endif()
+
 corrosion_import_crate(
     MANIFEST_PATH vortex-extension/Cargo.toml
     CRATES vortex-extension
     CRATE_TYPES ${VORTEX_LIB_TYPE}
     FLAGS --crate-type=${VORTEX_LIB_TYPE}
+    ${VORTEX_CARGO_PROFILE}
 )
 
 # Forward the DuckDB version passed via CMake as an env var.

--- a/vortex-extension/Cargo.toml
+++ b/vortex-extension/Cargo.toml
@@ -15,3 +15,8 @@ vortex-duckdb = { git = "https://github.com/vortex-data/vortex.git", rev = "7654
 # This improved build times significantly
 [profile.dev.package.vortex-fastlanes]
 debug = false
+
+[profile.release-lto]
+inherits = "release"
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
LTO allows us to save 17% of stripped and 23% of unstripped
.duckdb_extension size.

Cross-language LTO saves additional 1% but imposes clang-only
build with clang being same as LLVM version for rust toolchain so
not worth it.
