### PR TITLE
chore(renovate): stop bumping vortex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,15 @@
   "separateMinorPatch": true,
   "patch": {
     "groupName": "all patch updates"
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Vortex revisions are bumped manually, not by Renovate",
+      "matchDepNames": [
+        "vortex-duckdb",
+        "https://github.com/vortex-data/vortex.git"
+      ],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Renovate opens digest-bump PRs for the vortex-duckdb git dependency (e.g. #93). Vortex revisions are updated by hand, so disable Renovate updates for that dependency.