### PR TITLE
Apply patches from duckdb/duckdb

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.5
     with:
       ci_tools_version: v1.5.5
-      duckdb_version: v1.5.5
+      duckdb_version: fc4002c6e36f1e2d17d7c5b1a604777d69238d2b
       extension_name: vortex
       exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;windows_amd64;linux_amd64_musl"
       extra_toolchains: "rust"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ cmake_policy(SET CMP0135 NEW)
 set(TARGET_NAME vortex)
 project(${TARGET_NAME}_project)
 
+set(CMAKE_OSX_DEPLOYMENT_TARGET 12.0)
+if(UNIX AND NOT APPLE)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ftls-model=global-dynamic")
+endif()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
This PR applies patches from duckdb/duckdb:
- `pass-variable-through-cmake-not-make.patch`

It also bumps the duckdb submodules and `.github/workflows/MainDistributionPipeline.yml` to v2.0.0.
